### PR TITLE
Fixed module name in several files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-MouseX-Extend-*
+MouseX-Foreign-*
 .*
 !.gitignore
 !.shipit

--- a/Changes
+++ b/Changes
@@ -1,4 +1,8 @@
-Revision history for Perl extension MouseX::Extend
+Revision history for Perl extension MouseX::Foreign
+
+0.005 2011-10-13 09:40:21
+    - No code changes
+    - Fix module name in README, .gitignore, xt/podspell.t and Changes (this file)
 
 0.004 2011-03-27 16:16:43
     - Missing dependencies: Test::Exception

--- a/README
+++ b/README
@@ -1,11 +1,11 @@
-This is Perl module MouseX::Extend.
+This is Perl module MouseX::Foreign.
 
 INSTALLATION
 
-MouseX::Extend installation is straightforward. If your CPAN shell is set up,
+MouseX::Foreign installation is straightforward. If your CPAN shell is set up,
 you should just be able to do
 
-    $ cpan MouseX::Extend
+    $ cpan MouseX::Foreign
 
 Download it, unpack it, then build it as per the usual:
 
@@ -18,9 +18,9 @@ Then install it:
 
 DOCUMENTATION
 
-MouseX::Extend documentation is available as in POD. So you can do:
+MouseX::Foreign documentation is available as in POD. So you can do:
 
-    $ perldoc MouseX::Extend
+    $ perldoc MouseX::Foreign
 
 to read the documentation online with your favorite pager.
 

--- a/lib/MouseX/NonMoose.pm
+++ b/lib/MouseX/NonMoose.pm
@@ -1,0 +1,47 @@
+package MouseX::NonMoose;
+
+use Mouse;
+extends 'MouseX::Foreign';
+
+our $VERSION = '0.005';
+
+1;
+
+__END__
+
+=head1 NAME
+
+MouseX::NonMoose - MouseX::Foreign plus drop-in compatiblity with Any::Moose
+
+=head1 VERSION
+
+This document describes MouseX::Foreign version 0.005.
+
+=head1 SYNOPSIS
+
+    package MyInt;
+    use Any::Moose 'X::NonMoose';
+    extends 'Math::BigInt';
+
+    has name => (
+        is  => 'ro',
+        isa => 'Str',
+    );
+
+=head1 DESCRIPTION
+
+MouseX::NonMoose is a thin wrapper around L<MouseX::Foreign>, so as to be used
+with L<Any::Moose> and L<MooseX::NonMoose>;
+
+=head1 AUTHOR
+
+Fuji, Goro (gfx) E<lt>gfuji(at)cpan.orgE<gt>
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright (c) 2011, Fuji, Goro (gfx). All rights reserved.
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut

--- a/xt/podspell.t
+++ b/xt/podspell.t
@@ -15,9 +15,8 @@ all_pod_files_spelling_ok('lib');
 __DATA__
 Goro Fuji (gfx)
 gfuji(at)cpan.org
-MouseX::Extend
+MouseX::Foreign
 RT
 cpan
 destructor
 ACKNOWLEDGEMENT
-


### PR DESCRIPTION
In much of the documentation and other distribution files, the module is called "MouseX::Extend". This patch corrects these errors.
