### PR TITLE
MouseX::NonMoose for drop-in Any::Moose compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-MouseX-Extend-*
+MouseX-Foreign-*
 .*
 !.gitignore
 !.shipit

--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl extension MouseX::Foreign
 
+0.006 2011-10-13 10:47:07
+    - Add MouseX::NonMoose for drop-in compatibility with Any::Moose
+    - Add test files for new module
+
 0.005 2011-10-13 09:40:21
     - No code changes
     - Fix module name in README, .gitignore, xt/podspell.t and Changes (this file)

--- a/Changes
+++ b/Changes
@@ -1,4 +1,8 @@
-Revision history for Perl extension MouseX::Extend
+Revision history for Perl extension MouseX::Foreign
+
+0.005 2011-10-13 09:40:21
+    - No code changes
+    - Fix module name in README, .gitignore, xt/podspell.t and Changes (this file)
 
 0.004 2011-03-27 16:16:43
     - Missing dependencies: Test::Exception

--- a/README
+++ b/README
@@ -1,11 +1,11 @@
-This is Perl module MouseX::Extend.
+This is Perl module MouseX::Foreign.
 
 INSTALLATION
 
-MouseX::Extend installation is straightforward. If your CPAN shell is set up,
+MouseX::Foreign installation is straightforward. If your CPAN shell is set up,
 you should just be able to do
 
-    $ cpan MouseX::Extend
+    $ cpan MouseX::Foreign
 
 Download it, unpack it, then build it as per the usual:
 
@@ -18,9 +18,9 @@ Then install it:
 
 DOCUMENTATION
 
-MouseX::Extend documentation is available as in POD. So you can do:
+MouseX::Foreign documentation is available as in POD. So you can do:
 
-    $ perldoc MouseX::Extend
+    $ perldoc MouseX::Foreign
 
 to read the documentation online with your favorite pager.
 

--- a/lib/MouseX/NonMoose.pm
+++ b/lib/MouseX/NonMoose.pm
@@ -1,0 +1,47 @@
+package MouseX::NonMoose;
+
+use Mouse;
+extends 'MouseX::Foreign';
+
+our $VERSION = '0.005';
+
+1;
+
+__END__
+
+=head1 NAME
+
+MouseX::NonMoose - MouseX::Foreign plus drop-in compatiblity with Any::Moose
+
+=head1 VERSION
+
+This document describes MouseX::Foreign version 0.005.
+
+=head1 SYNOPSIS
+
+    package MyInt;
+    use Any::Moose 'X::NonMoose';
+    extends 'Math::BigInt';
+
+    has name => (
+        is  => 'ro',
+        isa => 'Str',
+    );
+
+=head1 DESCRIPTION
+
+MouseX::NonMoose is a thin wrapper around L<MouseX::Foreign>, so as to be used
+with L<Any::Moose> and L<MooseX::NonMoose>;
+
+=head1 AUTHOR
+
+Fuji, Goro (gfx) E<lt>gfuji(at)cpan.orgE<gt>
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright (c) 2011, Fuji, Goro (gfx). All rights reserved.
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut

--- a/lib/MouseX/NonMoose.pm
+++ b/lib/MouseX/NonMoose.pm
@@ -11,7 +11,7 @@ __END__
 
 =head1 NAME
 
-MouseX::NonMoose - MouseX::Foreign plus drop-in compatiblity with Any::Moose
+MouseX::NonMoose - MouseX::Foreign plus drop-in compatibility with Any::Moose
 
 =head1 VERSION
 

--- a/lib/MouseX/NonMoose/Meta/Role/Class.pm
+++ b/lib/MouseX/NonMoose/Meta/Role/Class.pm
@@ -1,0 +1,7 @@
+package MouseX::NonMoose::Meta::Role::Class;
+use Mouse::Role;
+use Mouse::Util::MetaRole;
+
+with 'MouseX::Foreign::Meta::Role::Class';
+
+1;

--- a/lib/MouseX/NonMoose/Meta/Role/Method/Constructor.pm
+++ b/lib/MouseX/NonMoose/Meta/Role/Method/Constructor.pm
@@ -1,0 +1,27 @@
+package MouseX::NonMoose::Meta::Role::Method::Constructor;
+use Mouse::Role;
+
+around _generate_constructor => sub {
+    my($next, undef, $meta, $option) = @_;
+
+    # The foreign superlcass must have the new method
+    my $foreign_buildargs  = $meta->name->can('FOREIGNBUILDARGS');
+    my $foreign_superclass = $meta->foreign_superclass;
+    my $super_new          = $foreign_superclass->can('new');
+    my $needs_buildall     = !$foreign_superclass->can('BUILDALL');
+
+    return sub {
+        my $class  = shift;
+        my $object = $foreign_buildargs
+            ? $class->$super_new($class->$foreign_buildargs(@_))
+            : $class->$super_new(                           @_ );
+        my $args = $class->BUILDARGS(@_);
+        $object->meta->_initialize_object($object, $args);
+        $object->BUILDALL($args) if $needs_buildall;
+
+        return $object;
+    };
+};
+
+no Mouse::Role;
+1;

--- a/lib/MouseX/NonMoose/Meta/Role/Method/Destructor.pm
+++ b/lib/MouseX/NonMoose/Meta/Role/Method/Destructor.pm
@@ -1,0 +1,26 @@
+package MouseX::NonMoose::Meta::Role::Method::Destructor;
+use Mouse::Role;
+
+around _generate_destructor => sub {
+    my($next, undef, $meta) = @_;
+
+    my $foreign_superclass = $meta->foreign_superclass;
+
+    my $super_destroy;
+    if(!$foreign_superclass->can('DEMOLISHALL')){
+        $super_destroy = $foreign_superclass->can('DESTROY');
+    }
+
+    return sub {
+        my($self) = @_;
+        $self->DEMOLISHALL();
+
+        if(defined $super_destroy) {
+            $self->$super_destroy();
+        }
+        return;
+    };
+};
+
+no Mouse::Role;
+1;

--- a/t/91-90-with-Any-Moose/001-basic.t
+++ b/t/91-90-with-Any-Moose/001-basic.t
@@ -1,0 +1,32 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+
+package Foo;
+
+sub new {
+    my $class = shift;
+    bless { _class => $class }, $class;
+}
+
+package Foo::Mouse;
+use Mouse;
+use Any::Moose 'X::NonMoose';
+extends 'Foo';
+
+package main;
+my $foo = Foo->new;
+my $foo_moose = Foo::Mouse->new;
+isa_ok($foo, 'Foo');
+is($foo->{_class}, 'Foo', 'Foo gets the correct class');
+isa_ok($foo_moose, 'Foo::Mouse');
+isa_ok($foo_moose, 'Foo');
+isa_ok($foo_moose, 'Mouse::Object');
+is($foo_moose->{_class}, 'Foo::Mouse', 'Foo::Mouse gets the correct class');
+my $meta = Foo::Mouse->meta;
+ok($meta->has_method('new'), 'Foo::Mouse has its own constructor');
+my $cc_meta = $meta->constructor_class->meta;
+isa_ok($cc_meta, 'Mouse::Meta::Class');
+
+done_testing;

--- a/t/91-90-with-Any-Moose/002-methods.t
+++ b/t/91-90-with-Any-Moose/002-methods.t
@@ -1,0 +1,25 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More tests => 3;
+
+package Foo;
+
+sub new { bless {}, shift }
+sub foo { 'Foo' }
+sub bar { 'Foo' }
+sub baz { ref(shift) }
+
+package Foo::Mouse;
+use Mouse;
+use Any::Moose 'X::NonMoose';
+extends 'Foo';
+
+sub bar { 'Foo::Mouse' }
+
+package main;
+
+my $foo_moose = Foo::Mouse->new;
+is($foo_moose->foo, 'Foo', 'Foo::Mouse->foo');
+is($foo_moose->bar, 'Foo::Mouse', 'Foo::Mouse->bar');
+is($foo_moose->baz, 'Foo::Mouse', 'Foo::Mouse->baz');

--- a/t/91-90-with-Any-Moose/003-attrs.t
+++ b/t/91-90-with-Any-Moose/003-attrs.t
@@ -1,0 +1,36 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+package Foo;
+
+sub new {
+    my $class = shift;
+    bless { @_ }, $class;
+}
+
+sub foo {
+    my $self = shift;
+    return $self->{foo} unless @_;
+    $self->{foo} = shift;
+}
+
+package Foo::Mouse;
+use Mouse;
+use Any::Moose 'X::NonMoose';
+extends 'Foo';
+
+has bar => (
+    is => 'rw',
+);
+
+package main;
+
+my $foo_moose = Foo::Mouse->new(foo => 'FOO', bar => 'BAR');
+is($foo_moose->foo, 'FOO', 'foo set in constructor');
+is($foo_moose->bar, 'BAR', 'bar set in constructor');
+$foo_moose->foo('BAZ');
+$foo_moose->bar('QUUX');
+is($foo_moose->foo, 'BAZ', 'foo set by accessor');
+is($foo_moose->bar, 'QUUX', 'bar set by accessor');

--- a/t/91-90-with-Any-Moose/004-multi-level.t
+++ b/t/91-90-with-Any-Moose/004-multi-level.t
@@ -1,0 +1,56 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More tests => 11;
+
+package Foo;
+
+sub new {
+    my $class = shift;
+    bless { foo => 'FOO' }, $class;
+}
+
+sub foo { shift->{foo} }
+
+package Foo::Mouse;
+use Mouse;
+use Any::Moose 'X::NonMoose';
+extends 'Foo';
+
+has bar => (
+    is      => 'ro',
+    default => 'BAR',
+);
+
+package Foo::Mouse::Sub;
+use Mouse;
+extends 'Foo::Mouse';
+
+has baz => (
+    is      => 'ro',
+    default => 'BAZ',
+);
+
+package main;
+my $foo_moose = Foo::Mouse->new;
+is($foo_moose->foo, 'FOO', 'Foo::Mouse::foo');
+is($foo_moose->bar, 'BAR', 'Foo::Mouse::bar');
+isnt(Foo::Mouse->meta->get_method('new'), undef,
+     'Foo::Mouse gets its own constructor');
+
+my $foo_moose_sub = Foo::Mouse::Sub->new;
+is($foo_moose_sub->foo, 'FOO', 'Foo::Mouse::Sub::foo');
+is($foo_moose_sub->bar, 'BAR', 'Foo::Mouse::Sub::bar');
+is($foo_moose_sub->baz, 'BAZ', 'Foo::Mouse::Sub::baz');
+is(Foo::Mouse::Sub->meta->get_method('new'), undef,
+   'Foo::Mouse::Sub just uses the constructor for Foo::Mouse');
+
+Foo::Mouse->meta->make_immutable;
+Foo::Mouse::Sub->meta->make_immutable;
+
+$foo_moose_sub = Foo::Mouse::Sub->new;
+is($foo_moose_sub->foo, 'FOO', 'Foo::Mouse::Sub::foo (immutable)');
+is($foo_moose_sub->bar, 'BAR', 'Foo::Mouse::Sub::bar (immutable)');
+is($foo_moose_sub->baz, 'BAZ', 'Foo::Mouse::Sub::baz (immutable)');
+isnt(Foo::Mouse::Sub->meta->get_method('new'), undef,
+     'Foo::Mouse::Sub has an inlined constructor');

--- a/t/91-90-with-Any-Moose/005-moose.t
+++ b/t/91-90-with-Any-Moose/005-moose.t
@@ -1,0 +1,51 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More tests => 12;
+
+package Foo;
+use Mouse;
+
+has foo => (
+    is      => 'ro',
+    default => 'FOO',
+);
+
+package Foo::Sub;
+use Mouse;
+use Any::Moose 'X::NonMoose';
+extends 'Foo';
+
+package main;
+my $foo_sub = Foo::Sub->new;
+isa_ok($foo_sub, 'Foo');
+is($foo_sub->foo, 'FOO', 'inheritance works');
+ok(!Foo::Sub->meta->has_method('new'),
+   'Foo::Sub doesn\'t have its own new method');
+
+$_->meta->make_immutable for qw(Foo Foo::Sub);
+
+$foo_sub = Foo::Sub->new;
+isa_ok($foo_sub, 'Foo');
+is($foo_sub->foo, 'FOO', 'inheritance works (immutable)');
+ok(Foo::Sub->meta->has_method('new'),
+   'Foo::Sub has its own new method (immutable)');
+
+package Foo::OtherSub;
+use Mouse;
+use Any::Moose 'X::NonMoose';
+extends 'Foo';
+
+package main;
+my $foo_othersub = Foo::OtherSub->new;
+isa_ok($foo_othersub, 'Foo');
+is($foo_othersub->foo, 'FOO', 'inheritance works (immutable when extending)');
+ok(!Foo::OtherSub->meta->has_method('new'),
+   'Foo::OtherSub doesn\'t have its own new method (immutable when extending)');
+
+Foo::OtherSub->meta->make_immutable;
+$foo_othersub = Foo::OtherSub->new;
+isa_ok($foo_othersub, 'Foo');
+is($foo_othersub->foo, 'FOO', 'inheritance works (all immutable)');
+ok(Foo::OtherSub->meta->has_method('new'),
+   'Foo::OtherSub has its own new method (all immutable)');

--- a/t/91-90-with-Any-Moose/006-disable.t
+++ b/t/91-90-with-Any-Moose/006-disable.t
@@ -1,0 +1,34 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More tests => 3;
+
+package Foo;
+
+sub new {
+    my $class = shift;
+    bless {}, $class;
+}
+
+package Foo::Mouse;
+use Mouse;
+use Any::Moose 'X::NonMoose';
+extends 'Foo';
+
+package Foo::Mouse2;
+use Mouse;
+use Any::Moose 'X::NonMoose';
+extends 'Foo';
+
+package main;
+
+ok(Foo::Mouse->meta->has_method('new'), 'Foo::Mouse has a constructor');
+my $method = Foo::Mouse->meta->get_method('new');
+Foo::Mouse->meta->make_immutable;
+isnt($method->body, Foo::Mouse->meta->get_method('new')->body,
+     'make_immutable replaced the constructor with an inlined version');
+
+my $method2 = Foo::Mouse2->meta->get_method('new');
+Foo::Mouse2->meta->make_immutable(inline_constructor => 0);
+is($method2->body, Foo::Mouse2->meta->get_method('new')->body,
+   'make_immutable doesn\'t replace the constructor if we ask it not to');

--- a/t/91-90-with-Any-Moose/010-immutable.t
+++ b/t/91-90-with-Any-Moose/010-immutable.t
@@ -1,0 +1,43 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More tests => 6;
+
+package Foo;
+
+sub new {
+    my $class = shift;
+    bless { @_ }, $class;
+}
+
+sub foo {
+    my $self = shift;
+    return $self->{foo} unless @_;
+    $self->{foo} = shift;
+}
+
+sub baz  { 'Foo' }
+sub quux { ref(shift) }
+
+package Foo::Mouse;
+use Mouse;
+use Any::Moose 'X::NonMoose';
+extends 'Foo';
+
+has bar => (
+    is => 'rw',
+);
+
+__PACKAGE__->meta->make_immutable;
+
+package main;
+
+my $foo_moose = Foo::Mouse->new(foo => 'FOO', bar => 'BAR');
+is($foo_moose->foo, 'FOO', 'foo set in constructor');
+is($foo_moose->bar, 'BAR', 'bar set in constructor');
+$foo_moose->foo('BAZ');
+$foo_moose->bar('QUUX');
+is($foo_moose->foo, 'BAZ', 'foo set by accessor');
+is($foo_moose->bar, 'QUUX', 'bar set by accessor');
+is($foo_moose->baz, 'Foo', 'baz method');
+is($foo_moose->quux, 'Foo::Mouse', 'quux method');

--- a/t/91-90-with-Any-Moose/020-BUILD.t
+++ b/t/91-90-with-Any-Moose/020-BUILD.t
@@ -1,0 +1,56 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More tests => 5;
+
+package Foo;
+
+sub new {
+    my $class = shift;
+    bless { foo => 'FOO' }, $class;
+}
+
+package Foo::Mouse;
+use Mouse;
+use Any::Moose 'X::NonMoose';
+extends 'Foo';
+
+has class => (
+    is => 'rw',
+);
+
+has accum => (
+    is      => 'rw',
+    isa     => 'Str',
+    default => '',
+);
+
+sub BUILD {
+    my $self = shift;
+    $self->class(ref $self);
+    $self->accum($self->accum . 'a');
+}
+
+package Foo::Mouse::Sub;
+use Mouse;
+extends 'Foo::Mouse';
+
+has bar => (
+    is => 'rw',
+);
+
+sub BUILD {
+    my $self = shift;
+    $self->bar('BAR');
+    $self->accum($self->accum . 'b');
+}
+
+package main;
+my $foo_moose = Foo::Mouse->new;
+is($foo_moose->class, 'Foo::Mouse', 'BUILD method called properly');
+is($foo_moose->accum, 'a', 'BUILD method called properly');
+
+my $foo_moose_sub = Foo::Mouse::Sub->new;
+is($foo_moose_sub->class, 'Foo::Mouse::Sub', 'parent BUILD method called');
+is($foo_moose_sub->bar, 'BAR', 'child BUILD method called');
+is($foo_moose_sub->accum, 'ab', 'BUILD methods called in the correct order');

--- a/t/91-90-with-Any-Moose/021-BUILDARGS.t
+++ b/t/91-90-with-Any-Moose/021-BUILDARGS.t
@@ -1,0 +1,39 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+package Foo;
+
+sub new {
+    my $class = shift;
+    bless { name => $_[0] }, $class;
+}
+
+sub name { shift->{name} }
+
+package Foo::Mouse;
+use Mouse;
+use Any::Moose 'X::NonMoose';
+extends 'Foo';
+
+has foo => (
+    is => 'rw',
+);
+
+sub BUILDARGS {
+    my $class = shift;
+    # remove the argument that's only for passing to the superclass constructor
+    shift;
+    return $class->SUPER::BUILDARGS(@_);
+}
+
+package main;
+
+my $foo = Foo::Mouse->new('bar', foo => 'baz');
+is($foo->name, 'bar', 'superclass constructor gets the right args');
+is($foo->foo,  'baz', 'subclass constructor gets the right args');
+Foo::Mouse->meta->make_immutable;
+$foo = Foo::Mouse->new('bar', foo => 'baz');
+is($foo->name, 'bar', 'superclass constructor gets the right args (immutable)');
+is($foo->foo,  'baz', 'subclass constructor gets the right args (immutable)');

--- a/t/91-90-with-Any-Moose/023-FOREIGNBUILDARGS.t
+++ b/t/91-90-with-Any-Moose/023-FOREIGNBUILDARGS.t
@@ -1,0 +1,79 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More tests => 12;
+
+package Foo;
+
+sub new {
+    my $class = shift;
+    bless { foo_base => $_[0] }, $class;
+}
+
+sub foo_base { shift->{foo_base} }
+
+package Foo::Mouse;
+use Mouse;
+use Any::Moose 'X::NonMoose';
+extends 'Foo';
+
+has foo => (
+    is => 'rw',
+);
+
+sub FOREIGNBUILDARGS {
+    my $class = shift;
+    my %args = @_;
+    return "$args{foo}_base";
+}
+
+package Bar::Mouse;
+use Mouse;
+use Any::Moose 'X::NonMoose';
+extends 'Foo';
+
+has bar => (
+    is => 'rw',
+);
+
+sub FOREIGNBUILDARGS {
+    my $class = shift;
+    return "$_[0]_base";
+}
+
+sub BUILDARGS {
+    my $class = shift;
+    return { bar => shift };
+}
+
+package Baz::Mouse;
+use Mouse;
+extends 'Bar::Mouse';
+
+has baz => (
+    is => 'rw',
+);
+
+package main;
+
+my $foo = Foo::Mouse->new(foo => 'bar');
+is($foo->foo,  'bar', 'subclass constructor gets the right args');
+is($foo->foo_base,  'bar_base', 'subclass constructor gets the right args');
+my $bar = Bar::Mouse->new('baz');
+is($bar->bar, 'baz', 'subclass constructor gets the right args');
+is($bar->foo_base, 'baz_base', 'subclass constructor gets the right args');
+my $baz = Baz::Mouse->new('bazbaz');
+is($baz->bar, 'bazbaz', 'extensions of extensions of the nonmoose class respect BUILDARGS');
+is($baz->foo_base, 'bazbaz_base', 'extensions of extensions of the nonmoose class respect FOREIGNBUILDARGS');
+Foo::Mouse->meta->make_immutable;
+Bar::Mouse->meta->make_immutable;
+Baz::Mouse->meta->make_immutable;
+$foo = Foo::Mouse->new(foo => 'bar');
+is($foo->foo,  'bar', 'subclass constructor gets the right args (immutable)');
+is($foo->foo_base,  'bar_base', 'subclass constructor gets the right args (immutable)');
+$bar = Bar::Mouse->new('baz');
+is($bar->bar, 'baz', 'subclass constructor gets the right args (immutable)');
+is($bar->foo_base, 'baz_base', 'subclass constructor gets the right args (immutable)');
+$baz = Baz::Mouse->new('bazbaz');
+is($baz->bar, 'bazbaz', 'extensions of extensions of the nonmoose class respect BUILDARGS (immutable)');
+is($baz->foo_base, 'bazbaz_base', 'extensions of extensions of the nonmoose class respect FOREIGNBUILDARGS (immutable)');

--- a/t/91-90-with-Any-Moose/024-nonmoose-moose-nonmoose.t
+++ b/t/91-90-with-Any-Moose/024-nonmoose-moose-nonmoose.t
@@ -1,0 +1,105 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More tests => 32;
+
+package Foo;
+
+sub new {
+    my $class = shift;
+    bless {@_}, $class;
+}
+
+sub foo { shift->{name} }
+
+package Foo::Mouse;
+use Mouse;
+use Any::Moose 'X::NonMoose';
+extends 'Foo';
+
+has foo2 => (
+    is => 'rw',
+    isa => 'Str',
+);
+
+package Foo::Mouse::Sub;
+use base 'Foo::Mouse';
+
+package Bar;
+
+sub new {
+    my $class = shift;
+    bless {name => $_[0]}, $class;
+}
+
+sub bar { shift->{name} }
+
+package Bar::Mouse;
+use Mouse;
+use Any::Moose 'X::NonMoose';
+extends 'Bar';
+
+has bar2 => (
+    is  => 'rw',
+    isa => 'Str',
+);
+
+sub FOREIGNBUILDARGS {
+    my $class = shift;
+    my %args = @_;
+    return $args{name};
+}
+
+package Bar::Mouse::Sub;
+use base 'Bar::Mouse';
+
+package main;
+my $foo = Foo::Mouse::Sub->new(name => 'foomoosesub', foo2 => 'FOO2');
+isa_ok($foo, 'Foo');
+isa_ok($foo, 'Foo::Mouse');
+is($foo->foo, 'foomoosesub', 'got name from nonmoose constructor');
+is($foo->foo2, 'FOO2', 'got attribute value from moose constructor');
+$foo = Foo::Mouse->new(name => 'foomoosesub', foo2 => 'FOO2');
+isa_ok($foo, 'Foo');
+isa_ok($foo, 'Foo::Mouse');
+is($foo->foo, 'foomoosesub', 'got name from nonmoose constructor');
+is($foo->foo2, 'FOO2', 'got attribute value from moose constructor');
+Foo::Mouse->meta->make_immutable;
+$foo = Foo::Mouse::Sub->new(name => 'foomoosesub', foo2 => 'FOO2');
+isa_ok($foo, 'Foo');
+isa_ok($foo, 'Foo::Mouse');
+TODO: {
+local $TODO = 'nonmoose-moose-nonmoose inheritance doesn\'t quite work';
+is($foo->foo, 'foomoosesub', 'got name from nonmoose constructor (immutable)');
+}
+is($foo->foo2, 'FOO2', 'got attribute value from moose constructor (immutable)');
+$foo = Foo::Mouse->new(name => 'foomoosesub', foo2 => 'FOO2');
+isa_ok($foo, 'Foo');
+isa_ok($foo, 'Foo::Mouse');
+is($foo->foo, 'foomoosesub', 'got name from nonmoose constructor (immutable)');
+is($foo->foo2, 'FOO2', 'got attribute value from moose constructor (immutable)');
+
+my $bar = Bar::Mouse::Sub->new(name => 'barmoosesub', bar2 => 'BAR2');
+isa_ok($bar, 'Bar');
+isa_ok($bar, 'Bar::Mouse');
+is($bar->bar, 'barmoosesub', 'got name from nonmoose constructor');
+is($bar->bar2, 'BAR2', 'got attribute value from moose constructor');
+$bar = Bar::Mouse->new(name => 'barmoosesub', bar2 => 'BAR2');
+isa_ok($bar, 'Bar');
+isa_ok($bar, 'Bar::Mouse');
+is($bar->bar, 'barmoosesub', 'got name from nonmoose constructor');
+is($bar->bar2, 'BAR2', 'got attribute value from moose constructor');
+Bar::Mouse->meta->make_immutable;
+$bar = Bar::Mouse::Sub->new(name => 'barmoosesub', bar2 => 'BAR2');
+isa_ok($bar, 'Bar');
+isa_ok($bar, 'Bar::Mouse');
+TODO: {
+local $TODO = 'nonmoose-moose-nonmoose inheritance doesn\'t quite work';
+is($bar->bar, 'barmoosesub', 'got name from nonmoose constructor (immutable)');
+}
+is($bar->bar2, 'BAR2', 'got attribute value from moose constructor (immutable)');
+$bar = Bar::Mouse->new(name => 'barmoosesub', bar2 => 'BAR2');
+isa_ok($bar, 'Bar');
+isa_ok($bar, 'Bar::Mouse');
+is($bar->bar, 'barmoosesub', 'got name from nonmoose constructor (immutable)');
+is($bar->bar2, 'BAR2', 'got attribute value from moose constructor (immutable)');

--- a/t/91-90-with-Any-Moose/030-only-metaclass-trait.t
+++ b/t/91-90-with-Any-Moose/030-only-metaclass-trait.t
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+package Foo;
+
+sub new { bless {}, shift }
+
+package Foo::Mouse;
+use Mouse -traits => 'MouseX::Foreign::Meta::Role::Class';
+extends 'Foo';
+
+package main;
+ok(Foo::Mouse->meta->has_method('new'),
+   'using only the metaclass trait still installs the constructor');
+isa_ok(Foo::Mouse->new, 'Mouse::Object');
+isa_ok(Foo::Mouse->new, 'Foo');
+my $method = Foo::Mouse->meta->get_method('new');
+Foo::Mouse->meta->make_immutable;
+{ local $TODO = "method object semantics is different from Moose's";
+is(Foo::Mouse->meta->get_method('new'), $method,
+   'inlining doesn\'t happen when the constructor trait isn\'t used');
+}

--- a/t/91-90-with-Any-Moose/031-moose-exporter.t
+++ b/t/91-90-with-Any-Moose/031-moose-exporter.t
@@ -1,0 +1,72 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More tests => 8;
+
+BEGIN {
+    require Mouse;
+    require Mouse::Util::MetaRole;
+
+    package Foo::Exporter::Class;
+    use Mouse::Exporter;
+    Mouse::Exporter->setup_import_methods(also => ['Mouse']);
+
+    sub init_meta {
+        shift;
+        my %options = @_;
+        Mouse->init_meta(%options);
+        return Mouse::Util::MetaRole::apply_metaclass_roles(
+            for_class               => $options{for_class},
+            metaclass_roles         => ['MouseX::NonMoose::Meta::Role::Class'],
+        );
+    }
+
+    package Foo::Exporter::ClassAndConstructor;
+    use Mouse::Exporter;
+    Mouse::Exporter->setup_import_methods(also => ['Mouse']);
+
+    sub init_meta {
+        shift;
+        my %options = @_;
+        Mouse->init_meta(%options);
+        return Mouse::Util::MetaRole::apply_metaclass_roles(
+            for_class               => $options{for_class},
+            metaclass_roles         => ['MouseX::NonMoose::Meta::Role::Class'],
+            constructor_class_roles =>
+                ['MouseX::NonMoose::Meta::Role::Method::Constructor'],
+        );
+    }
+
+}
+
+package Foo;
+
+sub new { bless {}, shift }
+
+package Foo::Mouse;
+BEGIN { Foo::Exporter::Class->import }
+extends 'Foo';
+
+package Foo::Mouse2;
+BEGIN { Foo::Exporter::ClassAndConstructor->import }
+extends 'Foo';
+
+package main;
+ok(Foo::Mouse->meta->has_method('new'),
+   'using only the metaclass trait still installs the constructor');
+isa_ok(Foo::Mouse->new, 'Mouse::Object');
+isa_ok(Foo::Mouse->new, 'Foo');
+my $method = Foo::Mouse->meta->get_method('new');
+Foo::Mouse->meta->make_immutable;
+{ local $TODO = "method objects has a different semantics from Moose's";
+is(Foo::Mouse->meta->get_method('new'), $method,
+   'inlining doesn\'t happen when the constructor trait isn\'t used');
+}
+ok(Foo::Mouse2->meta->has_method('new'),
+   'using only the metaclass trait still installs the constructor');
+isa_ok(Foo::Mouse2->new, 'Mouse::Object');
+isa_ok(Foo::Mouse2->new, 'Foo');
+my $method2 = Foo::Mouse2->meta->get_method('new');
+Foo::Mouse2->meta->make_immutable;
+isnt(Foo::Mouse2->meta->get_method('new'), $method2,
+   'inlining does happen when the constructor trait is used');

--- a/t/91-90-with-Any-Moose/040-destructor.t
+++ b/t/91-90-with-Any-Moose/040-destructor.t
@@ -1,0 +1,29 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+my $destroyed = 0;
+my $demolished = 0;
+package Foo;
+
+sub new { bless {}, shift }
+
+sub DESTROY { $destroyed++ }
+
+package Foo::Sub;
+use Mouse;
+use Any::Moose 'X::NonMoose';
+extends 'Foo';
+
+sub DEMOLISH { $demolished++ }
+
+package main;
+{ Foo::Sub->new }
+is($destroyed, 1, "non-Mouse destructor called");
+is($demolished, 1, "Mouse destructor called");
+Foo::Sub->meta->make_immutable;
+($destroyed, $demolished) = (0, 0);
+{ Foo::Sub->new }
+is($destroyed, 1, "non-Mouse destructor called (immutable)");
+is($demolished, 1, "Mouse destructor called (immutable)");

--- a/xt/podspell.t
+++ b/xt/podspell.t
@@ -15,9 +15,8 @@ all_pod_files_spelling_ok('lib');
 __DATA__
 Goro Fuji (gfx)
 gfuji(at)cpan.org
-MouseX::Extend
+MouseX::Foreign
 RT
 cpan
 destructor
 ACKNOWLEDGEMENT
-


### PR DESCRIPTION
This branch includes a wrapper, `MouseX::NonMoose` (subclass of `MouseX::Foreign`), as well as a copy of the `t/90-MooseX-NonMoose` test directory, called `t/91-90-with-Any-Moose`, with `MouseX::NonMoose` in place of `MouseX::Foreign`. Also includes the documentation fixes from commit `1a30b7b02ce6005acc7ed2417f75123430e51d29`.
