### PR TITLE
Work with a style of constructor which blesses its own args.

### DIFF
--- a/lib/MouseX/Foreign/Meta/Role/Method/Constructor.pm
+++ b/lib/MouseX/Foreign/Meta/Role/Method/Constructor.pm
@@ -12,10 +12,10 @@ around _generate_constructor => sub {
 
     return sub {
         my $class  = shift;
+        my $args = $class->BUILDARGS(@_);
         my $object = $foreign_buildargs
             ? $class->$super_new($class->$foreign_buildargs(@_))
             : $class->$super_new(                           @_ );
-        my $args = $class->BUILDARGS(@_);
         $object->meta->_initialize_object($object, $args);
         $object->BUILDALL($args) if $needs_buildall;
 

--- a/t/05_bless_new_args.t
+++ b/t/05_bless_new_args.t
@@ -1,0 +1,27 @@
+#!perl -w
+use strict;
+use Test::More;
+
+# A certain style of hand written constructor might bless its
+# arguments.  Test we don't choke because the arguments are apparently
+# not a hash.
+
+{
+    package Bless::Args;
+    sub new {
+        my($class, $args) = @_;
+        $args ||= {};
+        return bless $args, $class;
+    }
+}
+
+{
+    package Foo;
+    use Mouse;
+    use MouseX::Foreign;
+    extends 'Bless::Args';
+}
+
+new_ok 'Foo', [{ foo => 23 }];
+
+done_testing;


### PR DESCRIPTION
If the constructor is run before BUILDARGS, the args will be blessed.
BUILDARGS won't recognize it as a hash ref and will error.

App::Cmd::Command has this style of constructor.

MooseX::NonMoose calls BUILDARGS and FOREIGNBUILDARGS in this order.
