### PR TITLE
correction of the dependencies in the "test" phase.

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,7 +1,7 @@
 requires 'Mouse', '0.77';
 requires 'perl', '5.008001';
 
-on build => sub {
+on test => sub {
     requires 'Any::Moose', '0.15';
     requires 'Test::Exception';
     requires 'Test::More', '0.88';


### PR DESCRIPTION
Those dependency are for testing only, but not for buliding. Which
means that if a cpan client install this distribution without running
tests, then modules like `Any::Moose` should not be installed.

The intention here is to avoid installing `Any::Moose` as a runtime dependency. I had briefly tested this with `cpanm` and confiremd that, once `META.json` is regenerated (`minil dist`),  `cpanm --notest ` will not install `Any::Moose`.
